### PR TITLE
FISH-8344 Backport Fixes for CVE-2023-4043

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -86,9 +86,6 @@
                     <links>
                         <link>http://docs.oracle.com/javase/6/docs/api/</link>
                     </links>
-                    <doclint>none</doclint>
-                    <additionalOptions>-Xdoclint:none</additionalOptions>
-                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
 
                 <executions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -86,6 +86,9 @@
                     <links>
                         <link>http://docs.oracle.com/javase/6/docs/api/</link>
                     </links>
+                    <doclint>none</doclint>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
 
                 <executions>

--- a/bundles/licensee/pom.xml
+++ b/bundles/licensee/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>json-licensee-bundle</artifactId>

--- a/bundles/licensee/pom.xml
+++ b/bundles/licensee/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
     </parent>
 
     <artifactId>json-licensee-bundle</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -87,6 +87,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
                 <configuration>
                     <finalName>javax.json-ri-${impl_version}</finalName>
                     <descriptors>

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/src/main/java/org/glassfish/json/JsonArrayBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonArrayBuilderImpl.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.*;
 import java.io.StringWriter;
@@ -57,13 +57,15 @@ import java.util.List;
  * @author Jitendra Kotamraju
  */
 class JsonArrayBuilderImpl implements JsonArrayBuilder {
-    private ArrayList<JsonValue> valueList;
-    private final BufferPool bufferPool;
 
-    JsonArrayBuilderImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private ArrayList<JsonValue> valueList;
+    private final JsonContext jsonContext;
+
+    JsonArrayBuilderImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
+    @Override
     public JsonArrayBuilder add(JsonValue value) {
         validateValue(value);
         addValueList(value);
@@ -78,28 +80,28 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
 
     public JsonArrayBuilder add(BigDecimal value) {
         validateValue(value);
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     public JsonArrayBuilder add(BigInteger value) {
         validateValue(value);
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     public JsonArrayBuilder add(int value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     public JsonArrayBuilder add(long value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     public JsonArrayBuilder add(double value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
@@ -139,7 +141,7 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
             snapshot = Collections.unmodifiableList(valueList);
         }
         valueList = null;
-        return new JsonArrayImpl(snapshot, bufferPool);
+        return new JsonArrayImpl(snapshot, jsonContext);
     }
 
     private void addValueList(JsonValue value) {
@@ -157,11 +159,11 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
 
     private static final class JsonArrayImpl extends AbstractList<JsonValue> implements JsonArray {
         private final List<JsonValue> valueList;    // Unmodifiable
-        private final BufferPool bufferPool;
+        private final JsonContext jsonContext;
 
-        JsonArrayImpl(List<JsonValue> valueList, BufferPool bufferPool) {
+        JsonArrayImpl(List<JsonValue> valueList, JsonContext jsonContext) {
             this.valueList = valueList;
-            this.bufferPool = bufferPool;
+            this.jsonContext = jsonContext;
         }
 
         @Override
@@ -262,7 +264,7 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
         @Override
         public String toString() {
             StringWriter sw = new StringWriter();
-            JsonWriter jw = new JsonWriterImpl(sw, bufferPool);
+            JsonWriter jw = new JsonWriterImpl(sw, jsonContext);
             jw.write(this);
             jw.close();
             return sw.toString();

--- a/impl/src/main/java/org/glassfish/json/JsonBuilderFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonBuilderFactoryImpl.java
@@ -37,41 +37,40 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonBuilderFactoryImpl implements JsonBuilderFactory {
-    private final Map<String, ?> config;
-    private final BufferPool bufferPool;
 
-    JsonBuilderFactoryImpl(BufferPool bufferPool) {
-        this.config = Collections.emptyMap();
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonBuilderFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder() {
-        return new JsonObjectBuilderImpl(bufferPool);
+        return new JsonObjectBuilderImpl(jsonContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder() {
-        return new JsonArrayBuilderImpl(bufferPool);
+        return new JsonArrayBuilderImpl(jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
+
 }

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -35,7 +35,10 @@ import org.glassfish.json.api.JsonConfig;
 final class JsonContext {
 
     /** Default maximum value of BigInteger scale value limit. */
-    private static final int DEFAULT_MAX_BIGINT_SCALE = 100000;
+    private static final int DEFAULT_MAX_BIGINTEGER_SCALE = 100000;
+
+    /** Default maximum number of characters of BigDecimal source being parsed. */
+    private static final int DEFAULT_MAX_BIGDECIMAL_LEN = 1100;
 
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
@@ -46,6 +49,9 @@ final class JsonContext {
 
     // Maximum value of BigInteger scale value
     private final int bigIntegerScaleLimit;
+
+    // Maximum number of characters of BigDecimal source
+    private final int bigDecimalLengthLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -59,7 +65,8 @@ final class JsonContext {
      * @param defaultPool default char[] pool to use when no instance is configured
      */
     JsonContext(Map<String, ?> config, BufferPool defaultPool) {
-        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
+        this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null ? Collections.unmodifiableMap(config) : null;
@@ -73,7 +80,8 @@ final class JsonContext {
      * @param properties properties to store in local copy of provider specific properties {@code Map}
      */
     JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
-        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
+        this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null
@@ -90,6 +98,10 @@ final class JsonContext {
 
     int bigIntegerScaleLimit() {
         return bigIntegerScaleLimit;
+    }
+
+    int bigDecimalLengthLimit() {
+        return bigDecimalLengthLimit;
     }
 
     boolean prettyPrinting() {

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -40,6 +40,9 @@ final class JsonContext {
     /** Default maximum number of characters of BigDecimal source being parsed. */
     private static final int DEFAULT_MAX_BIGDECIMAL_LEN = 1100;
 
+    /** Default maximum level of nesting. */
+    private static final int DEFAULT_MAX_DEPTH = 1000;
+
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
      */
@@ -52,6 +55,9 @@ final class JsonContext {
 
     // Maximum number of characters of BigDecimal source
     private final int bigDecimalLengthLimit;
+
+    // Maximum depth to parse
+    private final int depthLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -67,6 +73,7 @@ final class JsonContext {
     JsonContext(Map<String, ?> config, BufferPool defaultPool) {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
+        this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null ? Collections.unmodifiableMap(config) : null;
@@ -82,6 +89,7 @@ final class JsonContext {
     JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
+        this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null
@@ -102,6 +110,10 @@ final class JsonContext {
 
     int bigDecimalLengthLimit() {
         return bigDecimalLengthLimit;
+    }
+
+    int depthLimit() {
+        return depthLimit;
     }
 
     boolean prettyPrinting() {

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Payara foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.json.JsonException;
+import javax.json.stream.JsonGenerator;
+import org.glassfish.json.api.BufferPool;
+import org.glassfish.json.api.JsonConfig;
+
+/**
+ * Parsson configuration.
+ * Values are composed from properties {@code Map}, system properties and default value.
+ */
+final class JsonContext {
+
+    /** Default maximum value of BigInteger scale value limit. */
+    private static final int DEFAULT_MAX_BIGINT_SCALE = 100000;
+
+    /**
+     * Custom char[] pool instance property. Can be set in properties {@code Map} only.
+     */
+    static final String PROPERTY_BUFFER_POOL = BufferPool.class.getName();
+
+    private final Map<String, ?> config;
+
+    // Maximum value of BigInteger scale value
+    private final int bigIntegerScaleLimit;
+
+    // Whether JSON pretty printing is enabled
+    private final boolean prettyPrinting;
+
+    private final BufferPool bufferPool;
+
+    /**
+     * Creates an instance of Parsson configuration.
+     *
+     * @param config a {@code Map} of provider specific properties to configure the JSON parsers
+     * @param defaultPool default char[] pool to use when no instance is configured
+     */
+    JsonContext(Map<String, ?> config, BufferPool defaultPool) {
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
+        this.bufferPool = getBufferPool(config, defaultPool);
+        this.config = config != null ? Collections.unmodifiableMap(config) : null;
+    }
+
+    /**
+     * Creates an instance of Parsson configuration.
+     *
+     * @param config a map of provider specific properties to configure the JSON parsers
+     * @param defaultPool default char[] pool to use when no instance is configured
+     * @param properties properties to store in local copy of provider specific properties {@code Map}
+     */
+    JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
+        this.bufferPool = getBufferPool(config, defaultPool);
+        this.config = config != null
+                ? Collections.unmodifiableMap(copyPropertiesMap(this, config, properties)) : null;
+    }
+
+    Map<String, ?> config() {
+        return config;
+    }
+
+    Object config(String propertyName) {
+        return config != null ? config.get(propertyName) : null;
+    }
+
+    int bigIntegerScaleLimit() {
+        return bigIntegerScaleLimit;
+    }
+
+    boolean prettyPrinting() {
+        return prettyPrinting;
+    }
+
+    BufferPool bufferPool() {
+        return bufferPool;
+    }
+
+    private static BufferPool getBufferPool(Map<String, ?> config, BufferPool defaultrPool) {
+        BufferPool pool = config != null ? (BufferPool)config.get(PROPERTY_BUFFER_POOL) : null;
+        return pool != null ? pool : defaultrPool;
+    }
+
+    private static int getIntConfig(String propertyName, Map<String, ?> config, int defaultValue) throws JsonException {
+        // Try config Map first
+        Integer intConfig = config != null ? getIntProperty(propertyName, config) : null;
+        if (intConfig != null) {
+            return intConfig;
+        }
+        // Try system properties as fallback.
+        intConfig = getIntSystemProperty(propertyName);
+        return intConfig != null ? intConfig : defaultValue;
+    }
+
+    private static boolean getBooleanConfig(String propertyName, Map<String, ?> config) throws JsonException {
+        // Try config Map first
+        Boolean booleanConfig = config != null ? getBooleanProperty(propertyName, config) : null;
+        if (booleanConfig != null) {
+            return booleanConfig;
+        }
+        // Try system properties as fallback.
+        return getBooleanSystemProperty(propertyName);
+    }
+
+    private static Integer getIntProperty(String propertyName, Map<String, ?> config) throws JsonException {
+        Object property = config.get(propertyName);
+        if (property == null) {
+            return null;
+        }
+        if (property instanceof Number) {
+            return ((Number) property).intValue();
+        }
+        if (property instanceof String) {
+            return propertyStringToInt(propertyName, (String) property);
+        }
+        throw new JsonException(
+                String.format("Could not convert %s property of type %s to Integer",
+                              propertyName, property.getClass().getName()));
+    }
+
+    // Returns true when property exists or null otherwise. Property value is ignored.
+    private static Boolean getBooleanProperty(String propertyName, Map<String, ?> config) throws JsonException {
+        return config.containsKey(propertyName) ? true : null;
+    }
+
+
+    private static Integer getIntSystemProperty(String propertyName) throws JsonException {
+        String systemProperty = getSystemProperty(propertyName);
+        if (systemProperty == null) {
+            return null;
+        }
+        return propertyStringToInt(propertyName, systemProperty);
+    }
+
+    // Returns true when property exists or false otherwise. Property value is ignored.
+    private static boolean getBooleanSystemProperty(String propertyName) throws JsonException {
+        return getSystemProperty(propertyName) != null;
+    }
+
+    @SuppressWarnings("removal")
+    private static String getSystemProperty(final String propertyName) throws JsonException {
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(
+                    new PrivilegedAction<String>() {
+                        @Override
+                        public String run() {
+                            return System.getProperty(propertyName);
+                        }
+                    });
+        } else {
+            return System.getProperty(propertyName);
+        }
+    }
+
+    private static int propertyStringToInt(String propertyName, String propertyValue) throws JsonException {
+        try {
+            return Integer.parseInt(propertyValue);
+        } catch (NumberFormatException ex) {
+            throw new JsonException(
+                    String.format("Value of %s property is not a number", propertyName), ex);
+        }
+    }
+
+    // Constructor helper: Copy provider specific properties Map. Only specified properties are added.
+    // Instance prettyPrinting and rejectDuplicateKeys variables must be initialized before
+    // this method is called.
+    private static Map<String, ?> copyPropertiesMap(JsonContext instance, Map<String, ?> config, String... properties) {
+        if (config == null) {
+            throw new NullPointerException("Map of provider specific properties is null");
+        }
+
+        if (properties == null || properties.length == 0) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> newConfig = new HashMap<String, Object>(properties.length);
+        for (String propertyName : properties) {
+            // Some properties need special handling.
+            if (propertyName.equals(JsonGenerator.PRETTY_PRINTING)) {
+                if (instance.prettyPrinting) {
+                    newConfig.put(JsonGenerator.PRETTY_PRINTING, true);
+                }
+                // Rest of properties are copied without changes
+            } else {
+                if (config.containsKey(propertyName)) {
+                    newConfig.put(propertyName, config.get(propertyName));
+                }
+            }
+        }
+        return newConfig;
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorFactoryImpl.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonGeneratorFactory;
@@ -54,41 +54,36 @@ import java.util.Map;
  */
 class JsonGeneratorFactoryImpl implements JsonGeneratorFactory {
 
-    private final boolean prettyPrinting;
-    private final Map<String, ?> config;    // unmodifiable map
-    private final BufferPool bufferPool;
+    private final JsonContext jsonContext;
 
-    JsonGeneratorFactoryImpl(Map<String, ?> config, boolean prettyPrinting,
-            BufferPool bufferPool) {
-        this.config = config;
-        this.prettyPrinting = prettyPrinting;
-        this.bufferPool = bufferPool;
+    JsonGeneratorFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonGenerator createGenerator(Writer writer) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(writer, bufferPool)
-                : new JsonGeneratorImpl(writer, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(writer, jsonContext)
+                : new JsonGeneratorImpl(writer, jsonContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(out, bufferPool)
-                : new JsonGeneratorImpl(out, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(out, jsonContext)
+                : new JsonGeneratorImpl(out, jsonContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out, Charset charset) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(out, charset, bufferPool)
-                : new JsonGeneratorImpl(out, charset, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(out, charset, jsonContext)
+                : new JsonGeneratorImpl(out, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 
 }

--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
 
@@ -114,18 +116,18 @@ class JsonGeneratorImpl implements JsonGenerator {
     private final char buf[];     // capacity >= INT_MIN_VALUE_CHARS.length
     private int len = 0;
 
-    JsonGeneratorImpl(Writer writer, BufferPool bufferPool) {
+    JsonGeneratorImpl(Writer writer, JsonContext jsonContext) {
+        this.bufferPool = jsonContext.bufferPool();
         this.writer = writer;
-        this.bufferPool = bufferPool;
-        this.buf = bufferPool.take();
+        this.buf = jsonContext.bufferPool().take();
     }
 
-    JsonGeneratorImpl(OutputStream out, BufferPool bufferPool) {
-        this(out, UTF_8, bufferPool);
+    JsonGeneratorImpl(OutputStream out, JsonContext jsonContext) {
+        this(out, UTF_8, jsonContext);
     }
 
-    JsonGeneratorImpl(OutputStream out, Charset encoding, BufferPool bufferPool) {
-        this(new OutputStreamWriter(out, encoding), bufferPool);
+    JsonGeneratorImpl(OutputStream out, Charset encoding, JsonContext jsonContext) {
+        this(new OutputStreamWriter(out, encoding), jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonMessages.java
+++ b/impl/src/main/java/org/glassfish/json/JsonMessages.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
 
@@ -54,6 +56,11 @@ import java.util.ResourceBundle;
 final class JsonMessages {
     private static final ResourceBundle BUNDLE =
             ResourceBundle.getBundle("org.glassfish.json.messages");
+
+    // global/shared messages
+    static String INTERNAL_ERROR() {
+        return localize("internal.error");
+    }
 
     // tokenizer messages
     static String TOKENIZER_UNEXPECTED_CHAR(int unexpected, JsonLocation location) {
@@ -88,6 +95,18 @@ final class JsonMessages {
 
     static String PARSER_GETBIGDECIMAL_ERR(JsonParser.Event event) {
         return localize("parser.getBigDecimal.err", event);
+    }
+
+    static String PARSER_GETARRAY_ERR(JsonParser.Event event) {
+        return localize("parser.getArray.err", event);
+    }
+
+    static String PARSER_GETOBJECT_ERR(JsonParser.Event event) {
+        return localize("parser.getObject.err", event);
+    }
+
+    static String PARSER_GETVALUE_ERR(JsonParser.Event event) {
+        return localize("parser.getValue.err", event);
     }
 
     static String PARSER_EXPECTED_EOF(JsonTokenizer.JsonToken token) {

--- a/impl/src/main/java/org/glassfish/json/JsonMessages.java
+++ b/impl/src/main/java/org/glassfish/json/JsonMessages.java
@@ -122,6 +122,10 @@ final class JsonMessages {
     }
 
 
+    static String PARSER_INPUT_NESTED_TOO_DEEP(int limit) {
+        return localize("parser.input.nested.too.deep", limit);
+    }
+
     // generator messages
     static String GENERATOR_FLUSH_IO_ERR() {
         return localize("generator.flush.io.err");
@@ -172,6 +176,10 @@ final class JsonMessages {
         return localize("reader.expected.object.got.array");
     }
 
+    // JSON number messages
+    static String NUMBER_SCALE_LIMIT_EXCEPTION(int value, int limit) {
+        return localize("number.scale.limit.exception", value, limit);
+    }
 
     // obj builder messages
     static String OBJBUILDER_NAME_NULL() {

--- a/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
@@ -243,25 +243,21 @@ abstract class JsonNumberImpl implements JsonNumber {
     @Override
     public BigInteger bigIntegerValue() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigInteger();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
     public BigInteger bigIntegerValueExact() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigIntegerExact();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonParserFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserFactoryImpl.java
@@ -37,10 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -49,33 +50,32 @@ import javax.json.stream.JsonParser;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonParserFactoryImpl implements JsonParserFactory {
-    private final Map<String, ?> config = Collections.emptyMap();
-    private final BufferPool bufferPool;
 
-    JsonParserFactoryImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonParserFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonParser createParser(Reader reader) {
-        return new JsonParserImpl(reader, bufferPool);
+        return new JsonParserImpl(reader, jsonContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in) {
-        return new JsonParserImpl(in, bufferPool);
+        return new JsonParserImpl(in, jsonContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in, Charset charset) {
-        return new JsonParserImpl(in, charset, bufferPool);
+        return new JsonParserImpl(in, charset, jsonContext);
     }
 
     @Override
@@ -85,7 +85,7 @@ class JsonParserFactoryImpl implements JsonParserFactory {
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -281,7 +281,7 @@ public class JsonParserImpl implements JsonParser {
 
         private void push(Context context) {
             if (++size >= limit) {
-                throw new RuntimeException("Input is too deeply nested " + size);
+                throw new RuntimeException(JsonMessages.PARSER_INPUT_NESTED_TOO_DEEP(size));
             }
             context.next = head;
             head = context;

--- a/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.stream.JsonGenerator;
 import java.io.OutputStream;
@@ -51,19 +51,20 @@ import java.nio.charset.Charset;
  * @author Jitendra Kotamraju
  */
 public class JsonPrettyGeneratorImpl extends JsonGeneratorImpl {
+
     private int indentLevel;
     private static final String INDENT = "    ";
 
-    public JsonPrettyGeneratorImpl(Writer writer, BufferPool bufferPool) {
-        super(writer, bufferPool);
+    public JsonPrettyGeneratorImpl(Writer writer, JsonContext jsonContext) {
+        super(writer, jsonContext);
     }
 
-    public JsonPrettyGeneratorImpl(OutputStream out, BufferPool bufferPool) {
-        super(out, bufferPool);
+    public JsonPrettyGeneratorImpl(OutputStream out, JsonContext jsonContext) {
+        super(out, jsonContext);
     }
 
-    public JsonPrettyGeneratorImpl(OutputStream out, Charset encoding, BufferPool bufferPool) {
-        super(out, encoding, bufferPool);
+    public JsonPrettyGeneratorImpl(OutputStream out, Charset encoding, JsonContext jsonContext) {
+        super(out, encoding, jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
@@ -86,7 +86,9 @@ public class JsonProviderImpl extends JsonProvider {
 
     @Override
     public JsonParserFactory createParserFactory(Map<String, ?> config) {
-        return new JsonParserFactoryImpl(new JsonContext(config, bufferPool));
+        return config == null
+                ? new JsonParserFactoryImpl(emptyContext)
+                : new JsonParserFactoryImpl(new JsonContext(config, bufferPool, JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
 
@@ -52,8 +54,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -62,145 +62,99 @@ import java.util.Map;
 public class JsonProviderImpl extends JsonProvider {
 
     private final BufferPool bufferPool = new BufferPoolImpl();
+    private final JsonContext emptyContext = new JsonContext(null, bufferPool);
 
     @Override
     public JsonGenerator createGenerator(Writer writer) {
-        return new JsonGeneratorImpl(writer, bufferPool);
+        return new JsonGeneratorImpl(writer, emptyContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out) {
-        return new JsonGeneratorImpl(out, bufferPool);
+        return new JsonGeneratorImpl(out, emptyContext);
     }
 
     @Override
     public JsonParser createParser(Reader reader) {
-        return new JsonParserImpl(reader, bufferPool);
+        return new JsonParserImpl(reader, emptyContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in) {
-        return new JsonParserImpl(in, bufferPool);
+        return new JsonParserImpl(in, emptyContext);
     }
 
     @Override
     public JsonParserFactory createParserFactory(Map<String, ?> config) {
-        BufferPool pool = null;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonParserFactoryImpl(pool);
+        return new JsonParserFactoryImpl(new JsonContext(config, bufferPool));
     }
 
     @Override
     public JsonGeneratorFactory createGeneratorFactory(Map<String, ?> config) {
-        Map<String, Object> providerConfig;
-        boolean prettyPrinting;
-        BufferPool pool;
-        if (config == null) {
-            providerConfig = Collections.emptyMap();
-            prettyPrinting = false;
-            pool = bufferPool;
-        } else {
-            providerConfig = new HashMap<String, Object>();
-            if (prettyPrinting=JsonProviderImpl.isPrettyPrintingEnabled(config)) {
-                providerConfig.put(JsonGenerator.PRETTY_PRINTING, true);
-            }
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-            if (pool != null) {
-                providerConfig.put(BufferPool.class.getName(), pool);
-            } else {
-                pool = bufferPool;
-            }
-            providerConfig = Collections.unmodifiableMap(providerConfig);
-        }
-
-        return new JsonGeneratorFactoryImpl(providerConfig, prettyPrinting, pool);
+        return config == null
+                ? new JsonGeneratorFactoryImpl(emptyContext)
+                : new JsonGeneratorFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonGenerator.PRETTY_PRINTING,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonReader createReader(Reader reader) {
-        return new JsonReaderImpl(reader, bufferPool);
+        return new JsonReaderImpl(reader, emptyContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in) {
-        return new JsonReaderImpl(in, bufferPool);
+        return new JsonReaderImpl(in, emptyContext);
     }
 
     @Override
     public JsonWriter createWriter(Writer writer) {
-        return new JsonWriterImpl(writer, bufferPool);
+        return new JsonWriterImpl(writer, emptyContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out) {
-        return new JsonWriterImpl(out, bufferPool);
+        return new JsonWriterImpl(out, emptyContext);
     }
 
     @Override
     public JsonWriterFactory createWriterFactory(Map<String, ?> config) {
-        Map<String, Object> providerConfig;
-        boolean prettyPrinting;
-        BufferPool pool;
-        if (config == null) {
-            providerConfig = Collections.emptyMap();
-            prettyPrinting = false;
-            pool = bufferPool;
-        } else {
-            providerConfig = new HashMap<String, Object>();
-            if (prettyPrinting=JsonProviderImpl.isPrettyPrintingEnabled(config)) {
-                providerConfig.put(JsonGenerator.PRETTY_PRINTING, true);
-            }
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-            if (pool != null) {
-                providerConfig.put(BufferPool.class.getName(), pool);
-            } else {
-                pool = bufferPool;
-            }
-            providerConfig = Collections.unmodifiableMap(providerConfig);
-        }
-        return new JsonWriterFactoryImpl(providerConfig, prettyPrinting, pool);
+        return config == null
+                ? new JsonWriterFactoryImpl(emptyContext)
+                : new JsonWriterFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonGenerator.PRETTY_PRINTING,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonReaderFactory createReaderFactory(Map<String, ?> config) {
-        BufferPool pool = null;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonReaderFactoryImpl(pool);
+        return config == null
+                ? new JsonReaderFactoryImpl(emptyContext)
+                : new JsonReaderFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder() {
-        return new JsonObjectBuilderImpl(bufferPool);
+        return new JsonObjectBuilderImpl(emptyContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder() {
-        return new JsonArrayBuilderImpl(bufferPool);
+        return new JsonArrayBuilderImpl(emptyContext);
     }
 
     @Override
     public JsonBuilderFactory createBuilderFactory(Map<String,?> config) {
-        BufferPool pool = null ;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonBuilderFactoryImpl(pool);
+        return config == null
+                ? new JsonBuilderFactoryImpl(emptyContext)
+                : new JsonBuilderFactoryImpl(
+                new JsonContext(config, bufferPool,
+                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
-    static boolean isPrettyPrintingEnabled(Map<String, ?> config) {
-        return config.containsKey(JsonGenerator.PRETTY_PRINTING);
-    }
 }

--- a/impl/src/main/java/org/glassfish/json/JsonReaderFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonReaderFactoryImpl.java
@@ -37,47 +37,46 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonReaderFactoryImpl implements JsonReaderFactory {
-    private final Map<String, ?> config = Collections.emptyMap();
-    private final BufferPool bufferPool;
 
-    JsonReaderFactoryImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonReaderFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonReader createReader(Reader reader) {
-        return new JsonReaderImpl(reader, bufferPool);
+        return new JsonReaderImpl(reader, jsonContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in) {
-        return new JsonReaderImpl(in, bufferPool);
+        return new JsonReaderImpl(in, jsonContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in, Charset charset) {
-        return new JsonReaderImpl(in, charset, bufferPool);
+        return new JsonReaderImpl(in, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 }

--- a/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
+++ b/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
@@ -42,13 +42,13 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
-
 import javax.json.JsonException;
 import javax.json.stream.JsonLocation;
 import javax.json.stream.JsonParser;
 import javax.json.stream.JsonParsingException;
-import java.io.*;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
@@ -76,7 +76,7 @@ final class JsonTokenizer implements Closeable {
     }
     private final static int HEX_LENGTH = HEX.length;
 
-    private final BufferPool bufferPool;
+    private final JsonContext jsonContext;
 
     private final Reader reader;
 
@@ -147,8 +147,8 @@ final class JsonTokenizer implements Closeable {
 
     JsonTokenizer(Reader reader, JsonContext jsonContext) {
         this.reader = reader;
-        this.bufferPool = jsonContext.bufferPool();
-        buf = bufferPool.take();
+        this.jsonContext = jsonContext;
+        buf = jsonContext.bufferPool().take();
     }
 
     private void readString() {
@@ -455,7 +455,7 @@ final class JsonTokenizer implements Closeable {
                 if (storeLen == buf.length) {
                     // buffer is full, double the capacity
                     char[] doubleBuf = Arrays.copyOf(buf, 2 * buf.length);
-                    bufferPool.recycle(buf);
+                    jsonContext.bufferPool().recycle(buf);
                     buf = doubleBuf;
                 } else {
                     // Left shift all the stored data to make space
@@ -492,7 +492,14 @@ final class JsonTokenizer implements Closeable {
 
     BigDecimal getBigDecimal() {
         if (bd == null) {
-            bd = new BigDecimal(buf, storeBegin, storeEnd-storeBegin);
+            int sourceLen = storeEnd - storeBegin;
+            if (sourceLen > jsonContext.bigDecimalLengthLimit()) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Number of BigDecimal source characters %d exceeded maximal allowed value of %d",
+                                sourceLen, jsonContext.bigDecimalLengthLimit()));
+            }
+            bd = new BigDecimal(buf, storeBegin, sourceLen);
         }
         return bd;
     }
@@ -533,7 +540,7 @@ final class JsonTokenizer implements Closeable {
     @Override
     public void close() throws IOException {
         reader.close();
-        bufferPool.recycle(buf);
+        jsonContext.bufferPool().recycle(buf);
     }
 
     private JsonParsingException unexpectedChar(int ch) {

--- a/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
+++ b/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
 
@@ -143,9 +145,9 @@ final class JsonTokenizer implements Closeable {
         }
     }
 
-    JsonTokenizer(Reader reader, BufferPool bufferPool) {
+    JsonTokenizer(Reader reader, JsonContext jsonContext) {
         this.reader = reader;
-        this.bufferPool = bufferPool;
+        this.bufferPool = jsonContext.bufferPool();
         buf = bufferPool.take();
     }
 
@@ -515,6 +517,13 @@ final class JsonTokenizer implements Closeable {
     boolean isDefinitelyInt() {
         int storeLen = storeEnd-storeBegin;
         return !fracOrExp && (storeLen <= 9 || (minus && storeLen == 10));
+    }
+
+    // returns true for common long values (1-18 digits).
+    // So there are cases it will return false even though the number is long
+    boolean isDefinitelyLong() {
+        int storeLen = storeEnd-storeBegin;
+        return !fracOrExp && (storeLen <= 18 || (minus && storeLen <= 19));
     }
 
     boolean isIntegral() {

--- a/impl/src/main/java/org/glassfish/json/JsonWriterFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonWriterFactoryImpl.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
@@ -53,34 +53,31 @@ import java.util.Map;
  * @author Jitendra Kotamraju
  */
 class JsonWriterFactoryImpl implements JsonWriterFactory {
-    private final Map<String, ?> config;        // unmodifiable map
-    private final boolean prettyPrinting;
-    private final BufferPool bufferPool;
 
-    JsonWriterFactoryImpl(Map<String, ?> config, boolean prettyPrinting,
-            BufferPool bufferPool) {
-        this.config = config;
-        this.prettyPrinting = prettyPrinting;
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonWriterFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonWriter createWriter(Writer writer) {
-        return new JsonWriterImpl(writer, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(writer, jsonContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out) {
-        return new JsonWriterImpl(out, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(out, jsonContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out, Charset charset) {
-        return new JsonWriterImpl(out, charset, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(out, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
+
 }

--- a/impl/src/main/java/org/glassfish/json/JsonWriterImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonWriterImpl.java
@@ -37,10 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.*;
 import java.io.FilterOutputStream;
@@ -62,33 +62,24 @@ class JsonWriterImpl implements JsonWriter {
     private boolean writeDone;
     private final NoFlushOutputStream os;
 
-    JsonWriterImpl(Writer writer, BufferPool bufferPool) {
-        this(writer, false, bufferPool);
+    JsonWriterImpl(Writer writer, JsonContext jsonContext) {
+        this.generator = jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(writer, jsonContext)
+                : new JsonGeneratorImpl(writer, jsonContext);
+        this.os = null;
     }
 
-    JsonWriterImpl(Writer writer, boolean prettyPrinting, BufferPool bufferPool) {
-        generator = prettyPrinting
-                ? new JsonPrettyGeneratorImpl(writer, bufferPool)
-                : new JsonGeneratorImpl(writer, bufferPool);
-        os = null;
+    JsonWriterImpl(OutputStream out, JsonContext jsonContext) {
+        this(out, UTF_8, jsonContext);
     }
 
-    JsonWriterImpl(OutputStream out, BufferPool bufferPool) {
-        this(out, UTF_8, false, bufferPool);
-    }
-
-    JsonWriterImpl(OutputStream out, boolean prettyPrinting, BufferPool bufferPool) {
-        this(out, UTF_8, prettyPrinting, bufferPool);
-    }
-
-    JsonWriterImpl(OutputStream out, Charset charset,
-                   boolean prettyPrinting, BufferPool bufferPool) {
+    JsonWriterImpl(OutputStream out, Charset charset, JsonContext jsonContext) {
         // Decorating the given stream, so that buffered contents can be
         // written without actually flushing the stream.
         this.os = new NoFlushOutputStream(out);
-        generator = prettyPrinting
-                ? new JsonPrettyGeneratorImpl(os, charset, bufferPool)
-                : new JsonGeneratorImpl(os, charset, bufferPool);
+        this.generator = jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(os, charset, jsonContext)
+                : new JsonGeneratorImpl(os, charset, jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -25,6 +25,13 @@ public interface JsonConfig {
      * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
      * Default value is set to {@code 100000}.
      */
-    String MAX_BIGINT_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+    String MAX_BIGINTEGER_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+
+    /**
+     * Configuration property to limit maximum value of BigDecimal length when being parsed.
+     * This property limits maximum number of characters of BigDecimal source being parsed.
+     * Default value is set to {@code 1100}.
+     */
+    String MAX_BIGDECIMAL_LEN = "org.eclipse.parsson.maxBigDecimalLength";
 
 }

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -19,8 +19,8 @@ package org.glassfish.json.api;
 public interface JsonConfig {
 
     /**
-     * Configuration property to limit maximum value of BigInteger scale value.
-     * This property limits maximum value of scale value to be allowed
+     * Configuration property to limit maximum absolute value of BigInteger scale.
+     * This property limits maximum absolute value of scale to be allowed
      * in {@link javax.json.JsonNumber#bigIntegerValue()}
      * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
      * Default value is set to {@code 100000}.

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.api;
+
+public interface JsonConfig {
+
+    /**
+     * Configuration property to limit maximum value of BigInteger scale value.
+     * This property limits maximum value of scale value to be allowed
+     * in {@link javax.json.JsonNumber#bigIntegerValue()}
+     * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
+     * Default value is set to {@code 100000}.
+     */
+    String MAX_BIGINT_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+
+}

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -34,4 +34,10 @@ public interface JsonConfig {
      */
     String MAX_BIGDECIMAL_LEN = "org.eclipse.parsson.maxBigDecimalLength";
 
+    /**
+     * Configuration property to limit maximum level of nesting when being parsing JSON string.
+     * Default value is set to {@code 1000}.
+     */
+    String MAX_DEPTH = "org.eclipse.parsson.maxDepth";
+
 }

--- a/impl/src/main/resources/org/glassfish/json/messages.properties
+++ b/impl/src/main/resources/org/glassfish/json/messages.properties
@@ -61,6 +61,7 @@ parser.getValue.err=JsonParser#getValue() is valid only for START_ARRAY, START_O
 parser.expected.eof=Expected EOF token, but got {0}
 parser.tokenizer.close.io=I/O error while closing JSON tokenizer
 parser.invalid.token=Invalid token={0} at {1}. Expected tokens are: {2}
+parser.input.nested.too.deep=Input is too deeply nested {0}
 
 generator.flush.io.err=I/O error while flushing generated JSON
 generator.close.io.err=I/O error while closing JsonGenerator
@@ -76,6 +77,8 @@ writer.write.already.called=write/writeObject/writeArray/close method is already
 reader.read.already.called=read/readObject/readArray/close method is already called
 reader.expected.array.got.object=Cannot read JSON array, found JSON object
 reader.expected.object.got.array=Cannot read JSON object, found JSON array
+
+number.scale.limit.exception=Scale value {0} of this BigInteger exceeded maximal allowed absolute value of {1}
 
 objbuilder.name.null=Name in JsonObject's name/value pair cannot be null
 objbuilder.value.null=Value in JsonObject's name/value pair cannot be null

--- a/impl/src/main/resources/org/glassfish/json/messages.properties
+++ b/impl/src/main/resources/org/glassfish/json/messages.properties
@@ -1,3 +1,47 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2013 Oracle and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+# or packager/legal/LICENSE.txt.  See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at packager/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# Oracle designates this particular file as subject to the "Classpath"
+# exception as provided by Oracle in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+# Portions Copyright 2024 Payara Foundation and/or its affiliates
+# Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
+
+internal.error=Internal Error
+
 parser.getString.err=JsonParser#getString() is valid only KEY_NAME, VALUE_STRING, VALUE_NUMBER parser states. \
   But current parser state is {0}
 parser.isIntegralNumber.err=JsonParser#isIntegralNumber() is valid only VALUE_NUMBER parser state. \
@@ -7,6 +51,12 @@ parser.getInt.err=JsonParser#getInt() is valid only VALUE_NUMBER parser state. \
 parser.getLong.err=JsonParser#getLong() is valid only VALUE_NUMBER parser state. \
   But current parser state is {0}
 parser.getBigDecimal.err=JsonParser#getBigDecimal() is valid only VALUE_NUMBER parser state. \
+  But current parser state is {0}
+parser.getArray.err=JsonParser#getArray() or JsonParser#getArrayStream() is valid only for START_ARRAY parser state. \
+  But current parser state is {0}
+parser.getObject.err=JsonParser#getObject() or JsonParser#getObjectStream() is valid only for START_OBJECT parser state. \
+  But current parser state is {0}
+parser.getValue.err=JsonParser#getValue() is valid only for START_ARRAY, START_OBJECT, KEY_NAME, VALUE_STRING, VALUE_NUMBER, VALUE_NULL, VALUE_FALSE, VALUE_TRUE parser states. \
   But current parser state is {0}
 parser.expected.eof=Expected EOF token, but got {0}
 parser.tokenizer.close.io=I/O error while closing JSON tokenizer

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,26 @@
                     <arguments>${release.arguments}</arguments>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>1.6</version>
+                            <vendor>zulu</vendor>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.8.1</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <additionalOptions>-Xdoclint:none</additionalOptions>
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.4.payara-p1</version>
+    <version>1.0.4.payara-p2-SNAPSHOT</version>
     <name>JSR 353 (JSON Processing) RI</name>
     <description>JSR 353:Java API for Processing JSON RI</description>
     <url>http://jsonp.java.net</url>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.4.payara-p1-SNAPSHOT</version>
+    <version>1.0.4.payara-p1</version>
     <name>JSR 353 (JSON Processing) RI</name>
     <description>JSR 353:Java API for Processing JSON RI</description>
     <url>http://jsonp.java.net</url>
@@ -62,7 +62,7 @@
         <connection>scm:git:git://java.net/jsonp~git/api</connection>
         <developerConnection>scm:git:ssh://jitu@git.java.net/jsonp~git/</developerConnection>
         <url>http://java.net/projects/jsonp/sources/git/show</url>
-      <tag>jsonp-1.0.4.payara-p1-SNAPSHOT</tag>
+      <tag>jsonp-1.0.4</tag>
   </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -151,11 +151,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.8.1</version>
-                    <configuration>
-                        <doclint>none</doclint>
-                        <additionalOptions>-Xdoclint:none</additionalOptions>
-                        <additionalparam>-Xdoclint:none</additionalparam>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
                     <artifactId>wagon-maven-plugin</artifactId>
                     <version>1.0-beta-4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1-SNAPSHOT</version>
+        <version>1.0.4.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.0.4.payara-p1</version>
+        <version>1.0.4.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalLengthLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalLengthLimitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import java.io.StringReader;
+import java.math.BigDecimal;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import junit.framework.TestCase;
+import org.glassfish.json.api.JsonConfig;
+
+/**
+ * Test maxBigDecimalLength limit set from System property.
+ */
+public class JsonBigDecimalLengthLimitTest extends TestCase  {
+
+    public JsonBigDecimalLengthLimitTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+        System.setProperty(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+    }
+
+    @Override
+    protected void tearDown() {
+        System.clearProperty(JsonConfig.MAX_BIGDECIMAL_LEN);
+    }
+
+    // Test BigDecimal max source characters array length using length equal to system property limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowLimit() {
+        JsonReader reader = Json.createReader(new StringReader("[" + JsonNumberTest.Π_500 + "]"));
+        JsonArray array = Json.createArrayBuilder().add(new BigDecimal(JsonNumberTest.Π_500)).build();
+        JsonNumber check = array.getJsonNumber(0);
+
+        JsonValue value = reader.readArray().get(0);
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length above system property limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalAboveLimit() {
+        JsonReader reader = Json.createReader(new StringReader("[" + JsonNumberTest.Π_501 + "]"));
+        try {
+            reader.readArray().get(0);
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 501 exceeded maximal allowed value of 500",
+                    e.getMessage());
+        }
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+
+import junit.framework.TestCase;
+
+/**
+ * Test maxBigIntegerScale limit set from System property.
+ */
+public class JsonBigDecimalScaleLimitTest extends TestCase {
+
+    public JsonBigDecimalScaleLimitTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+        System.setProperty("org.eclipse.parsson.maxBigIntegerScale", "50000");
+    }
+
+    @Override
+    protected void tearDown() {
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+    // Test BigInteger scale value limit set from system property using value bellow limit.
+    // Call shall return value.
+    public void testSystemPropertyBigIntegerScaleBellowLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433");
+        JsonArray array = Json.createArrayBuilder().add(value).build();
+        BigInteger integer = array.getJsonNumber(0).bigIntegerValue();
+        System.out.println(integer);
+    }
+
+    // Test BigInteger scale value limit set from system property using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Default value is 100000 and system property lowered it to 50000 so value with scale 50001
+    // test shall fail with exception message matching modified limits.
+    public void testSystemPropertyBigIntegerScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(50001, RoundingMode.HALF_UP);
+        try {
+            JsonArray array = Json.createArrayBuilder().add(value).build();
+            array.getJsonNumber(0).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    e.getMessage());
+        }
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
@@ -24,6 +24,7 @@ import javax.json.Json;
 import javax.json.JsonArray;
 
 import junit.framework.TestCase;
+import org.glassfish.json.api.JsonConfig;
 
 /**
  * Test maxBigIntegerScale limit set from System property.
@@ -36,12 +37,12 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
 
     @Override
     protected void setUp() {
-        System.setProperty("org.eclipse.parsson.maxBigIntegerScale", "50000");
+        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
     }
 
     @Override
     protected void tearDown() {
-        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+        System.clearProperty(JsonConfig.MAX_BIGINTEGER_SCALE);
     }
 
     // Test BigInteger scale value limit set from system property using value bellow limit.
@@ -49,8 +50,7 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
     public void testSystemPropertyBigIntegerScaleBellowLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433");
         JsonArray array = Json.createArrayBuilder().add(value).build();
-        BigInteger integer = array.getJsonNumber(0).bigIntegerValue();
-        System.out.println(integer);
+        array.getJsonNumber(0).bigIntegerValue();
     }
 
     // Test BigInteger scale value limit set from system property using value above limit.

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNestingTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNestingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+import javax.json.Json;
+import javax.json.stream.JsonParser;
+
+import java.io.StringReader;
+
+public class JsonNestingTest extends TestCase {
+
+    public void testNestingException() {
+        String json = createDeepNestedDoc(500);
+        StringReader stringReader = new StringReader(json);
+        JsonParser parser = Json.createParser(stringReader);
+        try {
+            while (parser.hasNext()) {
+                parser.next();
+            }
+            Assert.fail("Should have thrown a RuntimeException");
+        } catch (RuntimeException runtimeException) {
+            if (!runtimeException.getMessage().contains("Input is too deeply nested")) {
+                Assert.fail("RuntimeException did not contain expected message: " + runtimeException.getMessage());
+            }
+        } finally {
+            if (stringReader != null) {
+                stringReader.close();
+            }
+            if (parser != null) {
+                parser.close();
+            }
+        }
+    }
+
+    public void testNesting() {
+        String json = createDeepNestedDoc(499);
+        StringReader stringReader = new StringReader(json);
+        JsonParser parser = Json.createParser(stringReader);
+        try {
+            while (parser.hasNext()) {
+                parser.next();
+            }
+        } finally {
+            if (stringReader != null) {
+                stringReader.close();
+            }
+            if (parser != null) {
+                parser.close();
+            }
+        }
+    }
+
+    private static String createDeepNestedDoc(final int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (int i = 0; i < depth; i++) {
+            sb.append("{ \"a\": [");
+        }
+        sb.append(" \"val\" ");
+        for (int i = 0; i < depth; i++) {
+            sb.append("]}");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
@@ -51,6 +51,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.HashMap;
+import java.text.MessageFormat;
 import java.util.Map;
 
 import org.glassfish.json.api.JsonConfig;
@@ -82,6 +83,9 @@ public class JsonNumberTest extends TestCase {
 
     // π as JsonNumber with 1101 source characters
     private static final String Π_1101 = Π_1100 + "5";
+
+    // Default maximum value of BigInteger scale value limit from JsonContext
+    private static final int DEFAULT_MAX_BIGINTEGER_SCALE = 100000;
 
     public JsonNumberTest(String testName) {
         super(testName);
@@ -269,7 +273,7 @@ public class JsonNumberTest extends TestCase {
         array.getJsonNumber(0).bigIntegerValue();
     }
 
-    // Test default BigInteger scale value limit using value above limit.
+    // Test default BigInteger scale value limit using positive value above limit.
     // Call shall throw specific UnsupportedOperationException exception.
     public void testDefaultBigIntegerScaleAboveLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433")
@@ -280,9 +284,24 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 100001 of this BigInteger exceeded maximal allowed value of 100000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
+        }
+    }
+
+    // Test default BigInteger scale value limit using negative value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    public void testDefaultBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-100001, RoundingMode.HALF_UP);
+        try {
+            JsonArray array = Json.createArrayBuilder().add(value).build();
+            array.getJsonNumber(0).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertExceptionMessageContainsNumber(e, -100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
         }
     }
 
@@ -305,9 +324,32 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 50001);
+            assertExceptionMessageContainsNumber(e, 50000);
+        }
+    }
+
+    // Test BigInteger scale value limit set from config Map using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Config Map limit is stored in target JsonObject and shall be present for later value manipulation.
+    // Default value is 100000 and config Map property lowered it to 50000 so value with scale -50001
+    // test shall fail with exception message matching modified limits.
+    public void testConfigBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-50001, RoundingMode.HALF_UP);
+        Map<String, String> config = new HashMap<String, String>();
+        config.put(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
+        try {
+            JsonObject jsonObject = Json.createBuilderFactory(config)
+                    .createObjectBuilder()
+                    .add("bigDecimal", value)
+                    .build();
+            jsonObject.getJsonNumber("bigDecimal").bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertExceptionMessageContainsNumber(e, -50001);
+            assertExceptionMessageContainsNumber(e, 50000);
         }
     }
 
@@ -368,4 +410,12 @@ public class JsonNumberTest extends TestCase {
                     e.getMessage());
         }
     }
+
+    static void assertExceptionMessageContainsNumber(Exception e, int number) {
+        // Format the number as being written to message from messages bundle
+        String numberString = MessageFormat.format("{0}", number);
+        assertTrue("Substring \"" + numberString + "\" was not found in \"" + e.getMessage() + "\"",
+                   e.getMessage().contains(numberString));
+    }
+
 }

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
@@ -53,10 +53,36 @@ import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.glassfish.json.api.JsonConfig;
+
 /**
  * @author Jitendra Kotamraju
  */
 public class JsonNumberTest extends TestCase {
+
+    // π as JsonNumber with 500 source characters
+    static final String Π_500
+            = "3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706"
+            + "7982148086513282306647093844609550582231725359408128481117450284102701938521105559644622948954930381"
+            + "9644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412"
+            + "7372458700660631558817488152092096282925409171536436789259036001133053054882046652138414695194151160"
+            + "9433057270365759591953092186117381932611793105118548074462379962749567351885752724891227938183011949";
+
+    // π as JsonNumber with 501 source characters
+    static final String Π_501 = Π_500 + "1";
+
+    // π as JsonNumber with 1100 source characters
+    private static final String Π_1100 = Π_500
+            + "1298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051"
+            + "3200056812714526356082778577134275778960917363717872146844090122495343014654958537105079227968925892"
+            + "3542019956112129021960864034418159813629774771309960518707211349999998372978049951059731732816096318"
+            + "5950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473"
+            + "0359825349042875546873115956286388235378759375195778185778053217122680661300192787661119590921642019"
+            + "8938095257201065485863278865936153381827968230301952035301852968995773622599413891249721775283479131";
+
+    // π as JsonNumber with 1101 source characters
+    private static final String Π_1101 = Π_1100 + "5";
+
     public JsonNumberTest(String testName) {
         super(testName);
     }
@@ -240,8 +266,7 @@ public class JsonNumberTest extends TestCase {
     public void testDefaultBigIntegerScaleBellowLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433");
         JsonArray array = Json.createArrayBuilder().add(value).build();
-        BigInteger integer = array.getJsonNumber(0).bigIntegerValue();
-        System.out.println(integer);
+        array.getJsonNumber(0).bigIntegerValue();
     }
 
     // Test default BigInteger scale value limit using value above limit.
@@ -271,7 +296,6 @@ public class JsonNumberTest extends TestCase {
                 .setScale(50001, RoundingMode.HALF_UP);
         Map<String, String> config = new HashMap<String, String>();
         config.put("org.eclipse.parsson.maxBigIntegerScale", "50000");
-
         try {
             JsonObject jsonObject = Json.createBuilderFactory(config)
                     .createObjectBuilder()
@@ -283,6 +307,64 @@ public class JsonNumberTest extends TestCase {
             // UnsupportedOperationException is expected to be thrown
             assertEquals(
                     "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    e.getMessage());
+        }
+    }
+
+    // Test BigDecimal max source characters array length using length equal to default limit of 1100.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowLimit() {
+        JsonReader reader = Json.createReader(new StringReader("[" + Π_1100 + "]"));
+        JsonArray array = Json.createArrayBuilder().add(new BigDecimal(Π_1100)).build();
+        JsonNumber check = array.getJsonNumber(0);
+        JsonValue value = reader.readArray().get(0);
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length above default limit of 1100.
+    // Parsing shall throw specific UnsupportedOperationException exception.
+    public void testLargeBigDecimalAboveLimit() {
+        JsonReader reader = Json.createReader(new StringReader("[" + Π_1101 + "]"));
+        try {
+            reader.readArray().get(0);
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 1101 exceeded maximal allowed value of 1100",
+                    e.getMessage());
+        }
+    }
+
+    // Test BigDecimal max source characters array length using length equal to custom limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowCustomLimit() {
+        Map<String, String> config = new HashMap<String, String>();
+        config.put(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+
+        JsonReader reader = Json.createReaderFactory(config).createReader(new StringReader("[" + Π_500 + "]"));
+        JsonArray array = Json.createArrayBuilder().add(new BigDecimal(Π_500)).build();
+        JsonNumber check = array.getJsonNumber(0);
+        JsonValue value = reader.readArray().get(0);
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length equal to custom limit of 200.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalAboveCustomLimit() {
+        Map<String, String> config = new HashMap<String, String>();
+        config.put(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+
+        JsonReader reader = Json.createReaderFactory(config).createReader(new StringReader("[" + Π_501 + "]"));
+        try {
+            reader.readArray().get(0);
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 501 exceeded maximal allowed value of 500",
                     e.getMessage());
         }
     }


### PR DESCRIPTION
Backports fixes from Parsson to address the titular CVE.

The EE8 and EE7 versions of JSONP-Impl / Parsson are unsupported - Parsson don't even have a branch for it.
This means I've had to make some adjustments to the PRs, as they were built on top of all the other changes which have happened between EE7 and now (e.g. JSONP 1.1, JSONP 2.0, various unrelated Parsson features and refactors...).
I've tried to remove these where I can, but the first PR mixed in a big rework away from using a BufferPool class which I deemed too entwined to spend time unpicking.

I've also had to make adjustments to the code to be Java 6 compatible, and edited some of the unit tests to address the fact they're expecting JSONP 1.1 or later methods to be available.

As an aside, I elected to leave the new Parsson property names as they are rather than converting them to org.glassfish.json.* - I don't think it's worth changing them.

I've also had to introduce various changes to the build to allow compiling using latest Maven.
Building is accomplished by specifying the modules under the "release" profile + the testing module: `mvn clean install -pl . -pl .\impl\ -pl .\tests\`.
Make sure you have a toolchain set up for Java 6.

I've ran the unit tests and loaded the admin console in Payara as my local tests. I also ran it through the JavaEE7 samples, quicklook, and MicroProfile TCKs (in the absence of proper Jenkins testing for Payara 4).

I believe I've done the copyright correctly: brand new files retain Eclipse license, edits to existing ones get specified as GPLv2